### PR TITLE
Implememt Debug trait for the Packet enum

### DIFF
--- a/src/packet/cbr.rs
+++ b/src/packet/cbr.rs
@@ -2,7 +2,7 @@ use libipt_sys::{pt_packet_cbr, pt_packet_type_ppt_cbr};
 
 /// A CBR packet.
 /// Packet: cbr
-#[derive(Clone, Copy)]
+#[derive(Clone, Copy, Debug)]
 pub struct Cbr (pt_packet_cbr);
 impl Cbr {
     #[inline]

--- a/src/packet/cyc.rs
+++ b/src/packet/cyc.rs
@@ -2,7 +2,7 @@ use libipt_sys::{pt_packet_cyc, pt_packet_type_ppt_cyc};
 
 /// A CYC packet.
 /// Packet: cyc
-#[derive(Clone, Copy)]
+#[derive(Clone, Copy, Debug)]
 pub struct Cyc (pt_packet_cyc);
 impl Cyc {
     #[inline]

--- a/src/packet/invalid.rs
+++ b/src/packet/invalid.rs
@@ -1,6 +1,6 @@
 use libipt_sys::pt_packet;
 
-#[derive(Clone, Copy)]
+#[derive(Clone, Copy, Debug)]
 pub struct Invalid {}
 
 impl Into<Invalid> for pt_packet {

--- a/src/packet/ip.rs
+++ b/src/packet/ip.rs
@@ -15,7 +15,7 @@ use libipt_sys::{
 };
 
 /// The IP compression
-#[derive(Clone, Copy, TryFromPrimitive, IntoPrimitive)]
+#[derive(Clone, Copy, Debug, TryFromPrimitive, IntoPrimitive)]
 #[repr(i32)]
 pub enum Compression {
     /// No payload. The IP has been suppressed
@@ -39,7 +39,7 @@ pub enum Compression {
 
 /// A packet with IP payload.
 /// Packet: tip
-#[derive(Clone, Copy)]
+#[derive(Clone, Copy, Debug)]
 pub struct Tip (pt_packet_ip);
 impl Tip {
     #[inline]
@@ -71,7 +71,7 @@ impl Tip {
 
 /// A packet with IP payload.
 /// Packet: fup
-#[derive(Clone, Copy)]
+#[derive(Clone, Copy, Debug)]
 pub struct Fup (pt_packet_ip);
 impl Fup {
     #[inline]
@@ -103,7 +103,7 @@ impl Fup {
 
 /// A packet with IP payload.
 /// Packet: tip.pge
-#[derive(Clone, Copy)]
+#[derive(Clone, Copy, Debug)]
 pub struct TipPge (pt_packet_ip);
 impl TipPge {
     #[inline]
@@ -135,7 +135,7 @@ impl TipPge {
 
 /// A packet with IP payload.
 /// Packet: tip.pgd
-#[derive(Clone, Copy)]
+#[derive(Clone, Copy, Debug)]
 pub struct TipPgd (pt_packet_ip);
 impl TipPgd {
     #[inline]

--- a/src/packet/mnt.rs
+++ b/src/packet/mnt.rs
@@ -2,7 +2,7 @@ use libipt_sys::{pt_packet_mnt, pt_packet_type_ppt_mnt};
 
 /// A MNT packet.
 /// Packet: mnt
-#[derive(Clone, Copy)]
+#[derive(Clone, Copy, Debug)]
 pub struct Mnt (pt_packet_mnt);
 impl Mnt {
     #[inline]

--- a/src/packet/mod.rs
+++ b/src/packet/mod.rs
@@ -1,3 +1,5 @@
+use std::fmt::{Debug, Formatter};
+
 use libipt_sys::{
     pt_packet,
     pt_packet_type_ppt_cbr as PT_PACKET_TYPE_PPT_CBR,
@@ -137,6 +139,40 @@ pub enum Packet<T> {
     Pwre(pwre::Pwre),
     Pwrx(pwrx::Pwrx),
     Ptw(ptw::Ptw)
+}
+
+impl<T> Debug for Packet<T> {
+    fn fmt(&self, f: &mut Formatter) -> std::fmt::Result {
+        match self {
+            Self::Invalid(pack) => f.write_fmt(format_args!("Invalid({:?})", pack)),
+            Self::Psbend(pack) => f.write_fmt(format_args!("Psbend({:?})", pack)),
+            Self::Stop(pack) => f.write_fmt(format_args!("Stop({:?})", pack)),
+            Self::Pad(pack) => f.write_fmt(format_args!("Pad({:?})", pack)),
+            Self::Psb(pack) => f.write_fmt(format_args!("Psb({:?})", pack)),
+            Self::Ovf(pack) => f.write_fmt(format_args!("Ovf({:?})", pack)),
+            Self::Unknown(_) => f.write_str("Unknown"),
+            Self::Fup(pack) => f.write_fmt(format_args!("Fup({:?})", pack)),
+            Self::Tip(pack) => f.write_fmt(format_args!("Tip({:?})", pack)),
+            Self::TipPge(pack) => f.write_fmt(format_args!("TipPge({:?})", pack)),
+            Self::TipPgd(pack) => f.write_fmt(format_args!("TipPgd({:?})", pack)),
+            Self::Tnt8(pack) => f.write_fmt(format_args!("Tnt8({:?})", pack)),
+            Self::Tnt64(pack) => f.write_fmt(format_args!("Tnt64({:?})", pack)),
+            Self::Mode(pack) => f.write_fmt(format_args!("Mode({:?})", pack)),
+            Self::Pip(pack) => f.write_fmt(format_args!("Pip({:?})", pack)),
+            Self::Vmcs(pack) => f.write_fmt(format_args!("Vmcs({:?})", pack)),
+            Self::Cbr(pack) => f.write_fmt(format_args!("Cbr({:?})", pack)),
+            Self::Tsc(pack) => f.write_fmt(format_args!("Tsc({:?})", pack)),
+            Self::Tma(pack) => f.write_fmt(format_args!("Tma({:?})", pack)),
+            Self::Mtc(pack) => f.write_fmt(format_args!("Mtc({:?})", pack)),
+            Self::Cyc(pack) => f.write_fmt(format_args!("Cyc({:?})", pack)),
+            Self::Mnt(pack) => f.write_fmt(format_args!("Mnt({:?})", pack)),
+            Self::Exstop(pack) => f.write_fmt(format_args!("Exstop({:?})", pack)),
+            Self::Mwait(pack) => f.write_fmt(format_args!("Mwait({:?})", pack)),
+            Self::Pwre(pack) => f.write_fmt(format_args!("Pwre({:?})", pack)),
+            Self::Pwrx(pack) => f.write_fmt(format_args!("Pwrx({:?})", pack)),
+            Self::Ptw(pack) => f.write_fmt(format_args!("Ptw({:?})", pack)),
+        }
+    }
 }
 
 impl<T> From<pt_packet> for Packet<T> {

--- a/src/packet/mode.rs
+++ b/src/packet/mode.rs
@@ -1,3 +1,5 @@
+use std::fmt::{Debug, Formatter};
+
 use bitflags::bitflags;
 use libipt_sys::{
     pt_mode_leaf_pt_mol_exec as PT_MODE_LEAF_PT_MOL_EXEC,
@@ -107,7 +109,13 @@ impl Mode {
             Payload::Tsx(t)  => self.0.bits = t.into()
         }
     }
-} 
+}
+
+impl Debug for Mode {
+    fn fmt(&self, f: &mut Formatter) -> std::fmt::Result {
+        f.write_fmt(format_args!("Mode({{ leaf: {:?} }})", self.0.leaf))
+    }
+}
 
 wrap2raw!(Mode, pt_packet_type_ppt_mode, mode);
 raw2wrap!(Mode, Mode, pt_packet_mode);

--- a/src/packet/mtc.rs
+++ b/src/packet/mtc.rs
@@ -2,7 +2,7 @@ use libipt_sys::{pt_packet_mtc, pt_packet_type_ppt_mtc};
 
 /// A MTC packet.
 /// Packet: mtc
-#[derive(Clone, Copy)]
+#[derive(Clone, Copy, Debug)]
 pub struct Mtc (pt_packet_mtc);
 impl Mtc {
     #[inline]

--- a/src/packet/ovf.rs
+++ b/src/packet/ovf.rs
@@ -1,7 +1,7 @@
 use std::mem;
 use libipt_sys::{pt_packet, pt_packet_type_ppt_ovf};
 
-#[derive(Clone, Copy)]
+#[derive(Clone, Copy, Debug)]
 pub struct Ovf {}
 
 impl Ovf {

--- a/src/packet/pad.rs
+++ b/src/packet/pad.rs
@@ -1,7 +1,7 @@
 use std::mem;
 use libipt_sys::{pt_packet, pt_packet_type_ppt_pad};
 
-#[derive(Clone, Copy)]
+#[derive(Clone, Copy, Debug)]
 pub struct Pad {}
 
 impl Pad {

--- a/src/packet/pip.rs
+++ b/src/packet/pip.rs
@@ -6,7 +6,7 @@ use libipt_sys::{
 
 /// A PIP packet.
 /// Packet: pip
-#[derive(Clone, Copy)]
+#[derive(Clone, Copy, Debug)]
 pub struct Pip (pt_packet_pip);
 impl Pip {
     #[inline]

--- a/src/packet/psb.rs
+++ b/src/packet/psb.rs
@@ -1,7 +1,7 @@
 use std::mem;
 use libipt_sys::{pt_packet, pt_packet_type_ppt_psb};
 
-#[derive(Clone, Copy)]
+#[derive(Clone, Copy, Debug)]
 pub struct Psb {}
 
 impl Psb {

--- a/src/packet/psbend.rs
+++ b/src/packet/psbend.rs
@@ -1,7 +1,7 @@
 use std::mem;
 use libipt_sys::{pt_packet, pt_packet_type_ppt_psbend};
 
-#[derive(Clone, Copy)]
+#[derive(Clone, Copy, Debug)]
 pub struct Psbend {}
 
 impl Psbend {

--- a/src/packet/ptw.rs
+++ b/src/packet/ptw.rs
@@ -6,7 +6,7 @@ use libipt_sys::{
 
 /// A PTW packet.
 /// Packet: ptw
-#[derive(Clone, Copy)]
+#[derive(Clone, Copy, Debug)]
 pub struct Ptw (pt_packet_ptw);
 impl Ptw {
     #[inline]

--- a/src/packet/pwrx.rs
+++ b/src/packet/pwrx.rs
@@ -2,7 +2,7 @@ use libipt_sys::{pt_packet_pwrx, pt_packet_type_ppt_pwrx};
 
 /// A PWRX packet.
 /// Packet: pwrx
-#[derive(Clone, Copy)]
+#[derive(Clone, Copy, Debug)]
 pub struct Pwrx (pt_packet_pwrx);
 impl Pwrx {
     #[inline]

--- a/src/packet/stop.rs
+++ b/src/packet/stop.rs
@@ -1,7 +1,7 @@
 use std::mem;
 use libipt_sys::{pt_packet, pt_packet_type_ppt_stop};
 
-#[derive(Clone, Copy)]
+#[derive(Clone, Copy, Debug)]
 pub struct Stop {}
 
 impl Stop {

--- a/src/packet/tma.rs
+++ b/src/packet/tma.rs
@@ -2,7 +2,7 @@ use libipt_sys::{pt_packet_tma, pt_packet_type_ppt_tma};
 
 /// A TMA packet.
 /// Packet: tma
-#[derive(Clone, Copy)]
+#[derive(Clone, Copy, Debug)]
 pub struct Tma (pt_packet_tma);
 impl Tma {
     #[inline]

--- a/src/packet/tnt.rs
+++ b/src/packet/tnt.rs
@@ -6,7 +6,7 @@ use libipt_sys::{
 
 /// A TNT-8 packet.
 /// Packet: tnt-8
-#[derive(Clone, Copy)]
+#[derive(Clone, Copy, Debug)]
 pub struct Tnt8 (pt_packet_tnt);
 impl Tnt8 {
     #[inline]
@@ -32,7 +32,7 @@ impl Tnt8 {
 
 /// A TNT-64 packet.
 /// Packet: tnt-64
-#[derive(Clone, Copy)]
+#[derive(Clone, Copy, Debug)]
 pub struct Tnt64 (pt_packet_tnt);
 impl Tnt64 {
     #[inline]

--- a/src/packet/tsc.rs
+++ b/src/packet/tsc.rs
@@ -2,7 +2,7 @@ use libipt_sys::{pt_packet_tsc, pt_packet_type_ppt_tsc};
 
 /// A TSC packet.
 /// Packet: tsc
-#[derive(Clone, Copy)]
+#[derive(Clone, Copy, Debug)]
 pub struct Tsc (pt_packet_tsc);
 impl Tsc {
     #[inline]


### PR DESCRIPTION
Hi. Thanks for the amazing library.

`Debug` trait is not implemented for the `Packet` enum. This PR implements `Debug` trait for the `Packet` enum so that packets can be dumped to output.